### PR TITLE
fix: Remove last character from sql before executing to avoid syntax error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   
   <groupId>org.hisp</groupId>
   <artifactId>quick</artifactId>
-  <version>1.3.5</version>
+  <version>1.3.6</version>
   <packaging>jar</packaging>
   <name>Quick</name>
 	

--- a/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
+++ b/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
@@ -186,7 +186,7 @@ public abstract class AbstractBatchHandler<T>
             statementBuilder.getInsertStatementOpening() +
             statementBuilder.getInsertStatementValues( object );
 
-        sql = sql.substring(0, addObjectSqlBuffer.length() - 1 );
+        sql = sql.substring(0, sql.length() - 1 );
 
         log.debug( "Insert SQL: " + sql );
 

--- a/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
+++ b/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
@@ -182,9 +182,11 @@ public abstract class AbstractBatchHandler<T>
     @Override
     public boolean insertObject( T object )
     {
-        final String sql =
+        String sql =
             statementBuilder.getInsertStatementOpening() +
             statementBuilder.getInsertStatementValues( object );
+
+        sql = sql.substring(0, addObjectSqlBuffer.length() - 1 );
 
         log.debug( "Insert SQL: " + sql );
 

--- a/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
+++ b/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
@@ -186,7 +186,12 @@ public abstract class AbstractBatchHandler<T>
             statementBuilder.getInsertStatementOpening() +
             statementBuilder.getInsertStatementValues( object );
 
-        sql = sql.substring(0, sql.length() - 1 );
+        if ( sql.length() == 0 )
+        {
+            return false;
+        }
+
+        sql = sql.substring( 0, sql.length() - 1 );
 
         log.debug( "Insert SQL: " + sql );
 


### PR DESCRIPTION
Currently, the sql will finish with a "," at the end of the query. This commit will remove that comma, similar to what is done in addObject.