### PR TITLE
feat: Accept DataSource objects directly from clients using quick library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>2.3.4</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/hisp/quick/JdbcConfiguration.java
+++ b/src/main/java/org/hisp/quick/JdbcConfiguration.java
@@ -1,5 +1,7 @@
 package org.hisp.quick;
 
+import javax.sql.DataSource;
+
 /*
  * Copyright (c) 2004-2016, University of Oslo
  * All rights reserved.
@@ -37,14 +39,8 @@ public class JdbcConfiguration
 {
     private StatementDialect dialect;
     
-    private String driverClass;
+    private DataSource dataSource;
     
-    private String connectionUrl;
-    
-    private String username;
-    
-    private String password;
-
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -53,14 +49,10 @@ public class JdbcConfiguration
     {   
     }
     
-    public JdbcConfiguration( StatementDialect dialect, String driverClass, String connectionUrl,
-        String username, String password )
+    public JdbcConfiguration( StatementDialect dialect, DataSource dataSource )
     {
         this.dialect = dialect;
-        this.driverClass = driverClass;
-        this.connectionUrl = connectionUrl;
-        this.username = username;
-        this.password = password;
+        this.dataSource = dataSource;
     }
 
     // -------------------------------------------------------------------------
@@ -70,7 +62,7 @@ public class JdbcConfiguration
     @Override
     public String toString()
     {
-        return "[Dialect: " + dialect + ", driver class: " + driverClass + ", connection url: " + connectionUrl + ", username: " + username + ", password: " + password + "]";
+        return "[Dialect: " + dialect + ", dataSource runtime class: " + dataSource.getClass().getName() + "]";
     }
     
     // -------------------------------------------------------------------------
@@ -87,43 +79,14 @@ public class JdbcConfiguration
         this.dialect = dialect;
     }
     
-    public String getDriverClass()
+    public DataSource getDataSource()
     {
-        return driverClass;
+        return dataSource;
     }
 
-    public void setDriverClass( String driverClass )
+    public void setDataSource( DataSource dataSource )
     {
-        this.driverClass = driverClass;
+        this.dataSource = dataSource;
     }
 
-    public String getConnectionUrl()
-    {
-        return connectionUrl;
-    }
-
-    public void setConnectionUrl( String connectionUrl )
-    {
-        this.connectionUrl = connectionUrl;
-    }
-
-    public String getUsername()
-    {
-        return username;
-    }
-
-    public void setUsername( String username )
-    {
-        this.username = username;
-    }
-    
-    public String getPassword()
-    {
-        return password;
-    }
-
-    public void setPassword( String password )
-    {
-        this.password = password;
-    }
 }

--- a/src/main/java/org/hisp/quick/StatementInterceptor.java
+++ b/src/main/java/org/hisp/quick/StatementInterceptor.java
@@ -31,7 +31,6 @@ package org.hisp.quick;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hisp.quick.StatementManager;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
+++ b/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
@@ -29,7 +29,6 @@ package org.hisp.quick.batchhandler;
  */
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -100,12 +99,7 @@ public abstract class AbstractBatchHandler<T>
     {
         try
         {
-            Class.forName( configuration.getDriverClass() );
-
-            connection = DriverManager.getConnection(
-                configuration.getConnectionUrl(),
-                configuration.getUsername(),
-                configuration.getPassword() );
+            connection = configuration.getDataSource().getConnection();
 
             this.addObjectSqlBuffer = new StringBuffer( MAX_LENGTH );
             this.addObjectCount = 0;

--- a/src/main/java/org/hisp/quick/configuration/JdbcConfigurationFactoryBean.java
+++ b/src/main/java/org/hisp/quick/configuration/JdbcConfigurationFactoryBean.java
@@ -1,5 +1,7 @@
 package org.hisp.quick.configuration;
 
+import javax.sql.DataSource;
+
 /*
  * Copyright (c) 2004-2016, University of Oslo
  * All rights reserved.
@@ -61,33 +63,13 @@ public class JdbcConfigurationFactoryBean
         this.dialectName = dialectName;
     }
 
-    private String driverClass;
+    private DataSource dataSource;
 
-    public void setDriverClass( String driverClass )
+    public void setDataSource( DataSource dataSource )
     {
-        this.driverClass = driverClass;
+        this.dataSource = dataSource;
     }
 
-    private String connectionUrl;
-
-    public void setConnectionUrl( String connectionUrl )
-    {
-        this.connectionUrl = connectionUrl;
-    }
-
-    private String username;
-
-    public void setUsername( String username )
-    {
-        this.username = username;
-    }
-
-    private String password;
-
-    public void setPassword( String password )
-    {
-        this.password = password;
-    }
 
     // -------------------------------------------------------------------------
     // InitializingBean implementation
@@ -102,10 +84,7 @@ public class JdbcConfigurationFactoryBean
         StatementDialect _dialect = dialect != null ? dialect : StatementDialect.valueOf( dialectName );
         
         configuration.setDialect( _dialect );
-        configuration.setDriverClass( driverClass );
-        configuration.setConnectionUrl( connectionUrl );
-        configuration.setUsername( username );
-        configuration.setPassword( password );
+        configuration.setDataSource( dataSource );
         
         this.configuration = configuration;        
     }

--- a/src/main/java/org/hisp/quick/statement/JdbcStatementManager.java
+++ b/src/main/java/org/hisp/quick/statement/JdbcStatementManager.java
@@ -29,13 +29,13 @@ package org.hisp.quick.statement;
  */
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
 import org.hisp.quick.JdbcConfiguration;
 import org.hisp.quick.StatementDialect;
 import org.hisp.quick.StatementHolder;
 import org.hisp.quick.StatementManager;
+import org.hsqldb.jdbc.JDBCDataSource;
 
 /**
  * JDBC implementation of the StatementManager insterface.
@@ -45,7 +45,7 @@ import org.hisp.quick.StatementManager;
 public class JdbcStatementManager
     implements StatementManager
 {
-    public static final JdbcConfiguration IN_MEMORY_JDBC_CONFIG = new JdbcConfiguration( StatementDialect.HSQL, "org.hsqldb.jdbc.JDBCDriver", "jdbc:hsqldb:mem:quick", "SA", "" );
+    public static final JdbcConfiguration IN_MEMORY_JDBC_CONFIG = initializeInMemoryJdbcConfig() ;
     
     private ThreadLocal<StatementHolder> holderTag = new ThreadLocal<StatementHolder>();
 
@@ -138,6 +138,16 @@ public class JdbcStatementManager
     // Supportive methods
     // -------------------------------------------------------------------------
     
+    
+    private static JdbcConfiguration initializeInMemoryJdbcConfig()
+    {
+        JDBCDataSource ds = new JDBCDataSource();
+        ds.setUrl( "jdbc:hsqldb:mem:quick" );
+        ds.setUser( "SA" );
+        ds.setPassword( "" );
+        return new JdbcConfiguration( StatementDialect.HSQL, ds );
+    }
+    
     private Connection getConnection()
     {
         return getConnection( getConfiguration() );
@@ -147,12 +157,7 @@ public class JdbcStatementManager
     {
         try
         {            
-            Class.forName( config.getDriverClass() );
-            
-            Connection connection = DriverManager.getConnection( 
-                config.getConnectionUrl(),
-                config.getUsername(),
-                config.getPassword() );
+            Connection connection = config.getDataSource().getConnection();
             
             return connection;
         }

--- a/src/test/java/org/hisp/quick/statementbuilder/StatementBuilderTest.java
+++ b/src/test/java/org/hisp/quick/statementbuilder/StatementBuilderTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.*;
  */
 public class StatementBuilderTest
 {
-    private JdbcConfiguration postgreSqlJdbcConfig = new JdbcConfiguration( StatementDialect.POSTGRESQL, "driverClass", "connectionUrl", "username", "password" );
+    private JdbcConfiguration postgreSqlJdbcConfig = new JdbcConfiguration( StatementDialect.POSTGRESQL, null );
     
     @Test
     public void testDataValuePostgreSqlStatements()


### PR DESCRIPTION
1. Removed all references of DriverManager to ensure no explicit connections are creating by the quick library.
2. Username, password, connectionUrl are all removed from JdbcConfiguration and replaced by DataSource. This removes the need to pass db credentials to this library. 
3. Changed the hsqldb maven dependency scope to "compile", as it was required for InMemorryJdbcConfiguration.

**Note: I have not bumped up the version for the library in this PR currently but it should be done. My thought was to bump major/minor version and nott the patch version since its a breaking change for the clients But we can discuss.** 