### PR TITLE
Bump snapshot to 1.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   
   <groupId>org.hisp</groupId>
   <artifactId>quick</artifactId>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Quick</name>
 	

--- a/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
+++ b/src/main/java/org/hisp/quick/batchhandler/AbstractBatchHandler.java
@@ -310,15 +310,14 @@ public abstract class AbstractBatchHandler<T>
             throw new RuntimeException("Cannot flush a closed connection!");
         }
 
-        try ( Statement st = statement )
-        {
+        try {
             if ( addObjectSqlBuffer != null && addObjectSqlBuffer.length() > 2 && addObjectCount > 0 )
             {
                 addObjectSqlBuffer.deleteCharAt( addObjectSqlBuffer.length() - 1 );
 
                 log.debug( "Flush SQL: " + addObjectSqlBuffer );
 
-                st.executeUpdate( addObjectSqlBuffer.toString() );
+                statement.executeUpdate( addObjectSqlBuffer.toString() );
 
                 addObjectCount = 0;
 


### PR DESCRIPTION
- Remove statement from try-with-resources. Caused the statement to be closed twice. 