### PR TITLE
chore: Do not sign on pull-request workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,5 @@ jobs:
         env:
           SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
           SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          GPG_SECRET_KEYS: ${{ secrets.PGP_PRIVATE_KEY }}
         run: |
-          echo -e "$GPG_SECRET_KEYS" | gpg --import --no-tty --batch --yes
-          mvn clean deploy --settings .mvn/settings.xml -Dgpg.skip=false -Dmaven.test.skip=true -B
+          mvn clean deploy --settings .mvn/settings.xml -Dmaven.test.skip=true -B

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.hisp</groupId>
   <artifactId>quick</artifactId>
-  <version>1.4.5-SNAPSHOT</version>
+  <version>1.4.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Quick</name>
 


### PR DESCRIPTION
This PR removes the signing config in the pull-request workflow. This is done to prevent unintentional RELEASE publications from a Pull Request.